### PR TITLE
Improve app startup and directory cleanup robustness

### DIFF
--- a/app.py
+++ b/app.py
@@ -16,6 +16,11 @@ from apscheduler.schedulers.background import BackgroundScheduler
 # 创建 Flask 应用实例
 app = Flask(__name__)
 
+# 注册生成PCAP、suricata校验和Detect校验的蓝图，绑定到根路径下
+app.register_blueprint(generate_pcap_blueprint, url_prefix='/')
+app.register_blueprint(suricata_check_blueprint, url_prefix='/')
+app.register_blueprint(detect_check_blueprint, url_prefix='/')
+
 
 def clear_directories():
     """
@@ -23,12 +28,15 @@ def clear_directories():
 
     :return: None
     """
-    # BASE_DIR = os.getcwd()
-    # 设置基础目录路径，可以根据需要进行调整
-    BASE_DIR = '/var/www/web_apps/'
+    # 可通过环境变量覆盖基础目录，便于在不同部署环境复用
+    BASE_DIR = os.environ.get('WEB_APPS_BASE_DIR', '/var/www/web_apps/')
     # 定义需要清理的目录列表
     directories = [os.path.join(BASE_DIR, 'ruless'), os.path.join(BASE_DIR, 'pcapss')]
     for directory in directories:
+        # 目录不存在时跳过，避免定时任务异常中断
+        if not os.path.isdir(directory):
+            continue
+
         # 遍历目录中的所有文件和子目录，逐一删除
         for item in os.listdir(directory):
             file_path = os.path.join(directory, item)
@@ -81,10 +89,6 @@ if __name__ == '__main__':
     scheduler.add_job(func=clear_directories, trigger="interval", hours=16)
     scheduler.start()
 
-    # 注册生成PCAP、suricata校验和Detect校验的蓝图，绑定到根路径下
-    app.register_blueprint(generate_pcap_blueprint, url_prefix='/')
-    app.register_blueprint(suricata_check_blueprint, url_prefix='/')
-    app.register_blueprint(detect_check_blueprint, url_prefix='/')
     # app.run(debug=True, port=9900, host='0.0.0.0')
 
     # 启动 Flask 应用，启用调试模式，监听指定端口和IP地址


### PR DESCRIPTION
### Motivation
- Ensure Flask routes are available when the app is loaded by a WSGI server by registering blueprints at import time. 
- Make the cleanup path configurable so the scheduled cleaner can be reused across environments. 
- Prevent the scheduled cleanup job from failing when expected target directories are missing.

### Description
- Register the `generate_pcap`, `suricata_check`, and `detect_check` blueprints at module import so routes exist for WSGI deployments. 
- Read cleanup base path from the `WEB_APPS_BASE_DIR` environment variable with a default of `/var/www/web_apps/`. 
- Skip non-existent directories in `clear_directories()` before attempting to list or remove files to avoid exceptions. 
- Kept the existing runtime startup behavior in the `if __name__ == '__main__'` block unchanged.

### Testing
- Ran `python -m py_compile app.py generate_pcap.py` to verify there are no syntax errors and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b117481e3c83218bda90f8126743b8)